### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Checkout Repository
         if: steps.check.outputs.skip != 'true'
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           sparse-checkout: "icons"
 
@@ -93,7 +93,7 @@ jobs:
       - name: Generate token
         if: steps.check.outputs.skip != 'true'
         id: generate_token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           client-id: ${{ secrets.SYNC_L10N_APP_CLIENT_ID }}
           private-key: ${{ secrets.SYNC_L10N_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Pin all GitHub Actions to full commit SHAs (with version comments) via [pinact](https://github.com/suzuki-shunsuke/pinact), so a moved tag can't swap the action's code under us. Dependabot keeps the SHA and the comment up to date on future releases.